### PR TITLE
add auto draft workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,34 @@
+# GitHub Actions Workflows
+
+This directory contains GitHub Actions workflows that apply to all repositories in the organization.
+
+## Workflows
+
+### Auto Draft PR (`auto-draft-pr.yml`)
+
+Automatically converts all pull requests to draft state when they are opened. This ensures that developers must manually mark their PRs as "Ready for review" when they are actually ready for review.
+
+**Triggers:**
+- When a PR is opened
+- When a PR is reopened
+- When a PR is marked as "Ready for review"
+
+**Behavior:**
+- Converts non-draft PRs to draft state
+- Only runs if the PR is not already in draft state
+- Requires `pull-requests: write` permission
+
+**Benefits:**
+- Prevents accidental PR reviews on incomplete work
+- Encourages developers to be intentional about when their code is ready for review
+- Reduces noise in review queues
+- Improves code review quality by ensuring PRs are actually ready
+
+## Usage
+
+These workflows are automatically applied to all repositories in the organization. No additional configuration is required.
+
+## Permissions
+
+The workflows use minimal required permissions:
+- `pull-requests: write` - Only for the auto-draft PR workflow 

--- a/.github/workflows/auto-draft-pr.yml
+++ b/.github/workflows/auto-draft-pr.yml
@@ -1,0 +1,32 @@
+name: Auto Draft PR
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  auto-draft-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Set PR to draft
+        if: github.event.pull_request.draft == false
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            
+            if (!pullRequest.draft) {
+              await github.rest.pulls.convertToDraft({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number
+              });
+              
+              console.log(`Converted PR #${context.issue.number} to draft`);
+            } 

--- a/.github/workflows/auto-draft-pr.yml
+++ b/.github/workflows/auto-draft-pr.yml
@@ -15,11 +15,18 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.pulls.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number,
-              draft: true
-            });
+            console.log(`Attempting to convert PR #${context.issue.number} to draft...`);
             
-            console.log(`Converted PR #${context.issue.number} to draft`); 
+            try {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                draft: true
+              });
+              
+              console.log(`Successfully converted PR #${context.issue.number} to draft`);
+            } catch (error) {
+              console.error(`Error converting PR to draft:`, error);
+              throw error;
+            } 

--- a/.github/workflows/auto-draft-pr.yml
+++ b/.github/workflows/auto-draft-pr.yml
@@ -15,18 +15,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: pullRequest } = await github.rest.pulls.get({
+            await github.rest.pulls.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.issue.number
+              pull_number: context.issue.number,
+              draft: true
             });
             
-            if (!pullRequest.draft) {
-              await github.rest.pulls.convertToDraft({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: context.issue.number
-              });
-              
-              console.log(`Converted PR #${context.issue.number} to draft`);
-            } 
+            console.log(`Converted PR #${context.issue.number} to draft`); 


### PR DESCRIPTION
Adding workflow to automatically convert all new and reopened pull requests across the organization to a "Draft" state instead of defaulting to a "Ready for Review" state.